### PR TITLE
ci: checkout whole Git repo before using dorny/paths-filter

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -17,6 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions: {}
     steps:
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: changes
         with:


### PR DESCRIPTION
[GitHub Actions workflow runs in the main branch](https://github.com/suzuki-shunsuke/github-action-tfsec/actions?query=branch%3Amain) fail because of the following error:

> not a git repository (or any of the parent directories)

According to [the official GitHub Issue](https://github.com/dorny/paths-filter/issues/60#issuecomment-754725112), this is caused when we do not clone the repo by `actions/checkout` in advance, and use `push` event to run the build.

In my repo, I've confirmed that this change can stabilize the build triggered by `push` event, see [this example](https://github.com/KengoTODA/github-action-tfsec/actions/runs/5309263235/jobs/9609691125) for detail.