### PR TITLE
fix: exclude tfsec's transition message to parse output as JSON

### DIFF
--- a/aqua/aqua-checksums.json
+++ b/aqua/aqua-checksums.json
@@ -1,33 +1,33 @@
 {
   "checksums": [
     {
-      "id": "github_release/github.com/aquasecurity/tfsec/v1.28.1/tfsec-darwin-amd64",
-      "checksum": "C1D760AA8277E56F9DD44E9ED2267E11A746CC4B80DE124106B578414AD4A6C9",
+      "id": "github_release/github.com/aquasecurity/tfsec/v1.28.2/tfsec-darwin-amd64",
+      "checksum": "4ACF37F4F55DED6EEFD2AE3BBC0174AA2B1814068E722E845F54C888AD20239C",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/aquasecurity/tfsec/v1.28.1/tfsec-darwin-arm64",
-      "checksum": "7A8D528003C60661A445377A84BC0608A1B5F30FA2AFD1763268A80B8DE64E2D",
+      "id": "github_release/github.com/aquasecurity/tfsec/v1.28.2/tfsec-darwin-arm64",
+      "checksum": "B1379C536266E0314D4BF0F2DF8C32CDC345187C19FE5631499B48A873FB80B5",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/aquasecurity/tfsec/v1.28.1/tfsec-linux-amd64",
-      "checksum": "17C1BD99EBE13BE77AC775651BC61F44B2B4409B4578485F1168EAB8C3E97507",
+      "id": "github_release/github.com/aquasecurity/tfsec/v1.28.2/tfsec-linux-amd64",
+      "checksum": "B3E36C2C75809EA03AE6D496E2A67AC273E33F4B9625920B51DC0B47A759D90D",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/aquasecurity/tfsec/v1.28.1/tfsec-linux-arm64",
-      "checksum": "F2EAC8D5D0A12E9766182D190FE66AC5B8D5A341A0E07491883F733F1C159FBE",
+      "id": "github_release/github.com/aquasecurity/tfsec/v1.28.2/tfsec-linux-arm64",
+      "checksum": "326B3880B4BA8C803894B09804A05DBFCC3C5DE5688B4BA709D6AE158D39239C",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/aquasecurity/tfsec/v1.28.1/tfsec-windows-amd64.exe",
-      "checksum": "4FD5E7BEEC2A5EDEBCD687217CCE1B7DF0D52D0AB9283F19E04454DD6FE9A551",
+      "id": "github_release/github.com/aquasecurity/tfsec/v1.28.2/tfsec-windows-amd64.exe",
+      "checksum": "C3F674066482D1C6C075A47CC79915F1CEAD77CB4944DEBC09B3B5006E335BEB",
       "algorithm": "sha256"
     },
     {
-      "id": "github_release/github.com/aquasecurity/tfsec/v1.28.1/tfsec-windows-arm64.exe",
-      "checksum": "B7C458C6480F96A80213702B1225B45E4344B8F1CE62F2BC56844AF770FDA4BB",
+      "id": "github_release/github.com/aquasecurity/tfsec/v1.28.2/tfsec-windows-arm64.exe",
+      "checksum": "67E99C7BF852CCFA482258860F09BF6B937DEBF95654D8DBFA66695401BE9B61",
       "algorithm": "sha256"
     },
     {

--- a/aqua/imports/tfsec.yaml
+++ b/aqua/imports/tfsec.yaml
@@ -1,2 +1,2 @@
 packages:
-  - name: aquasecurity/tfsec@v1.28.1
+  - name: aquasecurity/tfsec@v1.28.2

--- a/dist/index.js
+++ b/dist/index.js
@@ -10865,6 +10865,18 @@ function getURL(result) {
     }
     return '';
 }
+function trimTrivyMessage(stdout) {
+    if (!stdout.startsWith('=')) {
+        return stdout;
+    }
+    const lines = stdout.split('\n').slice(1);
+    for (let i = 0; i < lines.length; i++) {
+        if (lines[i].startsWith('=')) {
+            return lines.slice(i + 1).join('\n');
+        }
+    }
+    return lines.join('\n');
+}
 const run = (inputs) => __awaiter(void 0, void 0, void 0, function* () {
     core.info('Running tfsec');
     const args = ['--format', 'json', '.'];
@@ -10876,7 +10888,9 @@ const run = (inputs) => __awaiter(void 0, void 0, void 0, function* () {
         ignoreReturnCode: true,
     });
     core.info('Parsing tfsec result');
-    const outJSON = JSON.parse(out.stdout);
+    // https://github.com/suzuki-shunsuke/github-action-tfsec/issues/618
+    const stdout = trimTrivyMessage(out.stdout);
+    const outJSON = JSON.parse(stdout);
     if (outJSON.results == null) {
         core.info('tfsec results is null');
         return;

--- a/dist/index.js
+++ b/dist/index.js
@@ -10889,7 +10889,7 @@ const run = (inputs) => __awaiter(void 0, void 0, void 0, function* () {
     });
     core.info('Parsing tfsec result');
     // https://github.com/suzuki-shunsuke/github-action-tfsec/issues/618
-    const stdout = trimTrivyMessage(out.stdout);
+    const stdout = trimTrivyMessage(out.stdout.trim());
     const outJSON = JSON.parse(stdout);
     if (outJSON.results == null) {
         core.info('tfsec results is null');

--- a/src/run.ts
+++ b/src/run.ts
@@ -107,7 +107,7 @@ export const run = async (inputs: Inputs): Promise<void> => {
   core.info('Parsing tfsec result');
 
   // https://github.com/suzuki-shunsuke/github-action-tfsec/issues/618
-  const stdout = trimTrivyMessage(out.stdout);
+  const stdout = trimTrivyMessage(out.stdout.trim());
 
   const outJSON = JSON.parse(stdout);
   if (outJSON.results == null) {

--- a/src/run.ts
+++ b/src/run.ts
@@ -81,6 +81,19 @@ function getURL(result: any): string {
   return '';
 }
 
+function trimTrivyMessage(stdout: string): string {
+  if (!stdout.startsWith('=')) {
+    return stdout;
+  }
+  const lines = stdout.split('\n').slice(1);
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith('=')) {
+      return lines.slice(i+1).join('\n');
+    }
+  }
+  return lines.join('\n');
+}
+
 export const run = async (inputs: Inputs): Promise<void> => {
   core.info('Running tfsec');
   const args = ['--format', 'json', '.'];
@@ -92,7 +105,11 @@ export const run = async (inputs: Inputs): Promise<void> => {
     ignoreReturnCode: true,
   });
   core.info('Parsing tfsec result');
-  const outJSON = JSON.parse(out.stdout);
+
+  // https://github.com/suzuki-shunsuke/github-action-tfsec/issues/618
+  const stdout = trimTrivyMessage(out.stdout);
+
+  const outJSON = JSON.parse(stdout);
   if (outJSON.results == null) {
     core.info('tfsec results is null');
     return;


### PR DESCRIPTION
- https://github.com/suzuki-shunsuke/github-action-tfsec/issues/618

## AS IS

👎 The action failed due to `Error: Unexpected token = in JSON at position 1`.

https://github.com/suzuki-shunsuke/github-action-tfsec/actions/runs/6127705347/job/16633873471?pr=621

```
Running tfsec
/home/runner/.local/share/aquaproj-aqua/bin/tfsec --format json .

======================================================
tfsec is joining the Trivy family

tfsec will continue to remain available 
for the time being, although our engineering 
attention will be directed at Trivy going forward.

You can read more here: 
https://github.com/aquasecurity/tfsec/discussions/1[9](https://github.com/suzuki-shunsuke/github-action-tfsec/actions/runs/6127705347/job/16633873471?pr=621#step:4:10)94
======================================================
{
	"results": []
}
Parsing tfsec result
Error: Unexpected token = in JSON at position 1
```

## TO BE

https://github.com/suzuki-shunsuke/github-action-tfsec/actions/runs/6127702469/job/16633866353?pr=620

👍 The action succeeded.

```
Running tfsec
/home/runner/.local/share/aquaproj-aqua/bin/tfsec --format json .

======================================================
tfsec is joining the Trivy family

tfsec will continue to remain available 
for the time being, although our engineering 
attention will be directed at Trivy going forward.

You can read more here: 
https://github.com/aquasecurity/tfsec/discussions/1[9](https://github.com/suzuki-shunsuke/github-action-tfsec/actions/runs/6127702469/job/16633866353?pr=620#step:4:10)94
======================================================
{
	"results": []
}
Parsing tfsec result
Running reviewdog
```