### PR TITLE
chore: update Node.js 16 to 20

### DIFF
--- a/action.yaml
+++ b/action.yaml
@@ -18,5 +18,5 @@ inputs:
     required: false
     default: 'false'
 runs:
-  using: node16
+  using: node20
   main: dist/index.js


### PR DESCRIPTION
https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/#for-actions-maintainers